### PR TITLE
Parsing attributes

### DIFF
--- a/backbone-model-factory.js
+++ b/backbone-model-factory.js
@@ -134,7 +134,7 @@
       // If there is a match in the cache, update its attributes based on the
       // passed-in attributes.
       } else {
-        model.set(attrs, options);
+        model.set(options && options.parse ? model.parse(attrs, options) : attrs, options);
       }
 
       // If no value for the idAttribute attribute was supplied, add a check


### PR DESCRIPTION
When options.parse is provided and the target already exists, it should parse the attributes before setting those.
